### PR TITLE
Fix duplicate symbol compile error.

### DIFF
--- a/src/markers.c
+++ b/src/markers.c
@@ -40,8 +40,7 @@ char *cdtext_data = NULL;
 
 /* The file selection widget and the string to store the chosen filename */
 
-GtkWidget *file_selector;
-gchar *selected_filename;
+extern GtkWidget *file_selector;
 gchar save_cdrdao_toc_filename[255] ;
 extern long num_song_markers, song_markers[] ;
 extern gchar wave_filename[] ;


### PR DESCRIPTION
When compiling this on Arch Linux, I had to make these changes to get it to work.

I am honestly not very familiar with GTK programming, so it might or might not be intended to share the `file_selector` widget between the two compilation units. It seems to work for me though.